### PR TITLE
Pull external release

### DIFF
--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -125,9 +125,8 @@ def helm_release(name, release_name, chart, values_yaml = None, values = None, r
         repo_adds.append("helm repo add {} {}".format(repo_name, repository))
         repo_adds.append("helm repo update")
         chartloc = "{}/{}".format(repo_name, chart_name)
-        if not version:
-            version = "latest"
-        set_version = "--version {} ".format(version)
+        if version:
+            set_version = "--version {} ".format(version)
     else:
         genrule_srcs.append(chart)
 

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -115,11 +115,13 @@ def helm_release(name, release_name, chart, values_yaml = None, values = None, r
     repo_adds = []
     if repository:
       repo_name = "bazel1"
+      chart_name = chart
       if len(chart.split("/")) > 1:
         repo_name = chart.split("/")[0]
+        chart_name = chart.split("/")[1]
       repo_adds.append("helm repo add {} {}".format(repo_name, repository))
       repo_adds.append("helm repo update")
-      chartloc = chart
+      chartloc = "{}/{}".format(repo_name, chart_name)
     else:
       genrule_srcs.append(chart)
 

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -145,6 +145,7 @@ else
 fi
 rm -rf .helm
 EOF"""
+    )
     _helm_cmd("install", ["upgrade", "--install"], name, helm_cmd_name, values_yaml, values)
     _helm_cmd("install.wait", ["upgrade", "--install", "--wait"], name, helm_cmd_name, values_yaml, values)
     _helm_cmd("status", ["status"], name, helm_cmd_name)

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -129,31 +129,22 @@ export XDG_CACHE_HOME=".helm/cache"
 export XDG_CONFIG_HOME=".helm/config"
 export XDG_DATA_HOME=".helm/data"
 mkdir -p .helm/cache .helm/config .helm/data
-{repo_adds}
-if [ -z "{repository}" ]; then
-  export CHARTLOC=$(location {chart})
+""" + "\n".join(repo_adds) + """
+if [ -z """ + "\"" + repository + "\"" + """]; then
+  export CHARTLOC=$(location """ + chart + """)
 else
-  export CHARTLOC=bazel1/{chart}
+  export CHARTLOC=bazel1/""" + chart + """
 fi
-EXPLICIT_NAMESPACE={namespace}
+EXPLICIT_NAMESPACE=""" + namespace + """
 NAMESPACE=\$${EXPLICIT_NAMESPACE:-\$$NAMESPACE}
 export NS=\$${NAMESPACE:-\$${BUILD_USER}}
 if [ "\$$1" == "upgrade" ]; then
-    helm \$$@ {release_name} \$$CHARTLOC --namespace \$$NS {set_params} {values_param}
+    helm \$$@ """ + release_name + " \$$CHARTLOC --namespace \$$NS " + set_params + " " + values_param + """
 else
-    helm \$$@ {release_name} --namespace \$$NS
+    helm \$$@ """ + release_name + " --namespace \$$NS " + """
 fi
 rm -rf .helm
-EOF""".format(
-          chart = chart,
-          namespace = namespace,
-          release_name = release_name,
-          set_params = set_params,
-          values_param = values_param,
-          repo_adds = "\n".join(repo_adds),
-          repository = repository,
-        )
-    )
+EOF"""
     _helm_cmd("install", ["upgrade", "--install"], name, helm_cmd_name, values_yaml, values)
     _helm_cmd("install.wait", ["upgrade", "--install", "--wait"], name, helm_cmd_name, values_yaml, values)
     _helm_cmd("status", ["status"], name, helm_cmd_name)

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -19,6 +19,7 @@ def helm_chart(name, srcs, update_deps = False, repositories = None):
         name: A unique name for this rule.
         srcs: Source files to include as the helm chart. Typically this will just be glob(["**"]).
         update_deps: Whether or not to run a helm dependency update prior to packaging.
+        repositories: A list of repositories to add and update to potentially be used as requirements/dependencies.
     """
     filegroup_name = name + "_filegroup"
     helm_cmd_name = name + "_package.sh"
@@ -100,10 +101,11 @@ def helm_release(name, release_name, chart, values_yaml = None, values = None, r
         chart: The chart defined by helm_chart.
         values_yaml: The values.yaml file to supply for the release.
         values: A map of additional values to supply for the release.
+        repository: A URL to a repository to install $chart from.
         namespace: The namespace to install the release into. If empty will default the NAMESPACE environment variable and will fall back the the current username (via BUILD_USER).
     """
     helm_cmd_name = name + "_run_helm_cmd.sh"
-    genrule_srcs = ["@com_github_deviavir_rules_helm//:runfiles_bash", chart]
+    genrule_srcs = ["@com_github_deviavir_rules_helm//:runfiles_bash"]
 
     # build --set params
     set_params = _build_helm_set_args(values)
@@ -112,6 +114,8 @@ def helm_release(name, release_name, chart, values_yaml = None, values = None, r
     if repository:
       repo_adds.append("helm repo add bazel1 {}".format(repository))
       repo_adds.append("helm repo update")
+    else:
+      genrule_srcs.append(chart)
 
     # build --values param
     values_param = ""


### PR DESCRIPTION
This enables the `helm_release` bazel rule to pull from a specified repository (possibly an internal mirror of an upstream) and install, even specific versions.